### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ Below is a list of terminals on which theme.sh is known to work:
  - [kitty](https://github.com/kovidgoyal/kitty) (not KiTTY)
  - gnome-terminal
  - terminator
- - st with the [appropriate patch](https://st.suckless.org/patches/osc_10_11_12_2)
+ - st
  - Terminal.app (osx)
  - iTerm2
  - alacritty


### PR DESCRIPTION
support for OSC color sequences is now built in vanilla st
http://git.suckless.org/st/commit/8e310303903792c010d03c046ba75f8b18f7d3a7.html