### PR TITLE
Only source theme.sh in interactive fish sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,26 +125,28 @@ fi
 ## `~/.config/fish/config.fish`
 
 ```
-if type -q theme.sh
-	if test -e ~/.theme_history
-	theme.sh (theme.sh -l|tail -n1)
-	end
+if status is-interactive
+    if type -q theme.sh
+        if test -e ~/.theme_history
+        theme.sh (theme.sh -l|tail -n1)
+        end
 
-	# Optional
-	# Bind C-o to the last theme.
-	function last_theme
-		theme.sh (theme.sh -l|tail -n2|head -n1)
-	end
+        # Optional
+        # Bind C-o to the last theme.
+        function last_theme
+            theme.sh (theme.sh -l|tail -n2|head -n1)
+        end
 
-	bind \co last_theme
+        bind \co last_theme
 
-	alias th='theme.sh -i'
+        alias th='theme.sh -i'
 
-	# Interactively load a light theme
-	alias thl='theme.sh --light -i'
+        # Interactively load a light theme
+        alias thl='theme.sh --light -i'
 
-	# Interactively load a dark theme
-	alias thd='theme.sh --dark -i'
+        # Interactively load a dark theme
+        alias thd='theme.sh --dark -i'
+    end
 end
 ```
 


### PR DESCRIPTION
I had the same issue as
https://www.reddit.com/r/neovim/comments/xr65ea/awk_error_when_calling_terminal_commands/, which is caused by theme.sh trying to apply the theme when vim is executing shell commands.

This commit amends the suggested default theme.sh loading logic for the fish shell to only apply when the shell is interactive. This seems like a generally sensible thing for a terminal theme manager regardless.