### PR TITLE
remove test for history file in configuration snippets in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ To load the most recently selected theme automatically you can put
 
 ```
 if command -v theme.sh > /dev/null; then
-	[ -e ~/.theme_history ] && theme.sh "$(theme.sh -l|tail -n1)"
+	theme.sh "$(theme.sh -l|tail -n1)"
 
 	# Optional
 
@@ -100,7 +100,7 @@ in your `~/.bashrc`.
 ## `~/.zshrc`
 ```
 if command -v theme.sh > /dev/null; then
-	[ -e ~/.theme_history ] && theme.sh "$(theme.sh -l|tail -n1)"
+	theme.sh "$(theme.sh -l|tail -n1)"
 
 	# Optional
 
@@ -126,9 +126,7 @@ fi
 
 ```
 if type -q theme.sh
-	if test -e ~/.theme_history
 	theme.sh (theme.sh -l|tail -n1)
-	end
 
 	# Optional
 	# Bind C-o to the last theme.


### PR DESCRIPTION
theme -l outputs a valid list, even if .theme_history does not exist. Furthermore, the location of the theme_history file depends on whether XDG_CONFIG_HOME is set or not.
```sh
config_dir = (ENVIRON["XDG_CONFIG_HOME"] ?  ENVIRON["XDG_CONFIG_HOME"] : ENVIRON["HOME"])
```
Omitting the test would therefore make the configuration more robust against changes to the theme_history file location.